### PR TITLE
Add checked usize arithmetic for Matrix indexing, make clippy fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,15 @@
 # `rscolorq` changelog
 
+## Version 0.1.2 - 2021-01-xx
+[#6][6] -  Add checked usize arithmetic for Matrix indexing, make clippy fixes
+[#5][5] -  Add safe wrapping usize arithmetic for Matrix2d indexing
+
 ## Version 0.1.1 - 2020-11-16
 Upgrade the dependencies because an upstream crate made it impossible to compile
 the crate and install it from crates.io using `cargo`.
 
 ## Version 0.1.0 - 2020-10-20
 - Initial Commit
+
+[6]: https://github.com/okaneco/rscolorq/pull/6
+[5]: https://github.com/okaneco/rscolorq/pull/5

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -29,21 +29,15 @@ checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 
 [[package]]
 name = "bytemuck"
-version = "1.4.1"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41aa2ec95ca3b5c54cf73c91acf06d24f4495d5f1b1c12506ae3483d646177ac"
+checksum = "5a4bad0c5981acc24bc09e532f35160f952e35422603f0563cd7a73c2c2e65a0"
 
 [[package]]
 name = "byteorder"
-version = "1.3.4"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de"
-
-[[package]]
-name = "cfg-if"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
+checksum = "ae44d1a3d5a19df61dd0c8beb138458ac2a53a7ac09eba97d55592540004306b"
 
 [[package]]
 name = "cfg-if"
@@ -74,7 +68,7 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81156fece84ab6a9f2afdb109ce3ae577e42b1228441eded99bd77f627953b1a"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
 ]
 
 [[package]]
@@ -89,29 +83,29 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.1.15"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc587bc0ec293155d5bfa6b9891ec18a1e330c234f896ea47fbada4cadbe47e6"
+checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if",
  "libc",
  "wasi",
 ]
 
 [[package]]
 name = "heck"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205"
+checksum = "87cbf45460356b7deeb5e3415b5563308c0a9b057c85e12b06ad551f98d0a6ac"
 dependencies = [
  "unicode-segmentation",
 ]
 
 [[package]]
 name = "image"
-version = "0.23.11"
+version = "0.23.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4f0a8345b33b082aedec2f4d7d4a926b845cee184cbe78b703413066564431b"
+checksum = "293f07a1875fa7e9c5897b51aa68b2d8ed8271b87e1a44cb64b9c3d98aabbc0d"
 dependencies = [
  "bytemuck",
  "byteorder",
@@ -125,12 +119,9 @@ dependencies = [
 
 [[package]]
 name = "jpeg-decoder"
-version = "0.1.20"
+version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc797adac5f083b8ff0ca6f6294a999393d76e197c36488e2ef732c4715f6fa3"
-dependencies = [
- "byteorder",
-]
+checksum = "229d53d58899083193af11e15917b5640cd40b29ff475a1fe4ef725deb02d0f2"
 
 [[package]]
 name = "lazy_static"
@@ -140,9 +131,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.80"
+version = "0.2.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d58d1b70b004888f764dfbf6a26a3b0342a1632d33968e4a179d8011c760614"
+checksum = "b7282d924be3275cec7f6756ff4121987bc6481325397dde6ba3e7802b1a8b1c"
 
 [[package]]
 name = "miniz_oxide"
@@ -218,9 +209,9 @@ dependencies = [
 
 [[package]]
 name = "png"
-version = "0.16.7"
+version = "0.16.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfe7f9f1c730833200b134370e1d5098964231af8450bce9b78ee3ab5278b970"
+checksum = "3c3287920cb847dee3de33d301c463fba14dda99db24214ddf93f83d3021f4c6"
 dependencies = [
  "bitflags",
  "crc32fast",
@@ -269,9 +260,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.7"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa563d17ecb180e500da1cfd2b028310ac758de548efdd203e18f283af693f37"
+checksum = "991431c3519a3f36861882da93630ce66b52918dcf1b8e2fd66b397fc96f28df"
 dependencies = [
  "proc-macro2",
 ]
@@ -328,7 +319,7 @@ dependencies = [
 
 [[package]]
 name = "rscolorq"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "image",
  "palette",
@@ -339,9 +330,9 @@ dependencies = [
 
 [[package]]
 name = "structopt"
-version = "0.3.20"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "126d630294ec449fae0b16f964e35bf3c74f940da9dca17ee9b905f7b3112eb8"
+checksum = "5277acd7ee46e63e5168a80734c9f6ee81b1367a7d8772a2d765df2a3705d28c"
 dependencies = [
  "clap",
  "lazy_static",
@@ -350,9 +341,9 @@ dependencies = [
 
 [[package]]
 name = "structopt-derive"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65e51c492f9e23a220534971ff5afc14037289de430e3c83f9daf6a1b6ae91e8"
+checksum = "5ba9cdfda491b814720b6b06e0cac513d922fc407582032e8706e9f137976f90"
 dependencies = [
  "heck",
  "proc-macro-error",
@@ -363,9 +354,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.48"
+version = "1.0.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc371affeffc477f42a221a1e4297aedcea33d47d19b61455588bd9d8f6b19ac"
+checksum = "c700597eca8a5a762beb35753ef6b94df201c81cca676604f547495a0d7f0081"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -383,9 +374,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.7.0"
+version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db8716a166f290ff49dabc18b44aa407cb7c6dbe1aa0971b44b8a24b0ca35aae"
+checksum = "bb0d2e7be6ae3a5fa87eed5fb451aff96f2573d2694942e40543ae0bbe19c796"
 
 [[package]]
 name = "unicode-width"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "rscolorq"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["okaneco <47607823+okaneco@users.noreply.github.com>"]
 edition = "2018"
-exclude = ["test", "gfx"]
+exclude = ["test", "gfx", ".github"]
 description = "Spatial color quantization, a Rust port of `scolorq`."
 homepage = "https://github.com/okaneco/rscolorq"
 repository = "https://github.com/okaneco/rscolorq"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # rscolorq
+[![Build Status](https://img.shields.io/github/workflow/status/okaneco/rscolorq/Rust%20CI/master)](https://github.com/okaneco/rscolorq)
 [![Crates.io](https://img.shields.io/crates/v/rscolorq.svg)](https://crates.io/crates/rscolorq)
 [![Docs.rs](https://docs.rs/rscolorq/badge.svg)](https://docs.rs/rscolorq)
 
@@ -142,5 +143,9 @@ This crate is licensed under either
 - the [Apache License (Version 2.0)](LICENSE-APACHE)
 
 at your option.
+
+Unless you explicitly state otherwise, any contribution intentionally submitted
+for inclusion in the work by you, as defined in the Apache-2.0 license, shall be
+dual licensed as above, without any additional terms or conditions.
 
 *Copyright of the original images is property of their respective owners.*

--- a/src/bin/rscolorq/args.rs
+++ b/src/bin/rscolorq/args.rs
@@ -1,5 +1,3 @@
-use std::path::PathBuf;
-
 use structopt::StructOpt;
 
 #[derive(StructOpt, Debug)]
@@ -7,11 +5,11 @@ use structopt::StructOpt;
 pub struct Opt {
     /// Input file.
     #[structopt(short, long, parse(from_os_str))]
-    pub input: PathBuf,
+    pub input: std::path::PathBuf,
 
     /// Output file.
     #[structopt(short, long, parse(from_os_str))]
-    pub output: Option<PathBuf>,
+    pub output: Option<std::path::PathBuf>,
 
     /// Number of colors to dither.
     #[structopt(short, long, default_value = "8", required = false)]
@@ -60,7 +58,7 @@ pub struct Opt {
 
     /// Output file.
     #[structopt(long = "op", parse(from_os_str))]
-    pub palette_output: Option<PathBuf>,
+    pub palette_output: Option<std::path::PathBuf>,
 
     /// Filter size.
     #[structopt(long, default_value = "3", required = false, hidden = true)]

--- a/src/bin/rscolorq/utils.rs
+++ b/src/bin/rscolorq/utils.rs
@@ -119,7 +119,7 @@ pub fn save_palette(
                     .min(len as f32))
                 .round() as usize,
             )
-            .unwrap();
+            .ok_or("Could not retrieve color for saving palette")?;
         *pixel = image::Rgb(color);
     }
 
@@ -156,7 +156,7 @@ pub fn save_palette_lab(
                     .min(len as f32))
                 .round() as usize,
             )
-            .unwrap();
+            .ok_or("Could not retrieve color for saving palette")?;
         *pixel = image::Rgb([color.red, color.green, color.blue]);
     }
 

--- a/src/color/lab.rs
+++ b/src/color/lab.rs
@@ -16,8 +16,9 @@ impl SpatialQuant for Lab<D65, f64> {
                             / dithering_level.powi(2))
                         .exp();
                         sum += val;
-                        *filter_weights.get_mut(i as usize, j as usize).unwrap() =
-                            Lab::new(val, val, val);
+                        *filter_weights
+                            .get_mut(i as usize, j as usize)
+                            .expect("filter weights index in range") = Lab::new(val, val, val);
                     }
                 }
                 filter_weights.iter_mut().for_each(|fw| *fw /= sum);
@@ -31,8 +32,9 @@ impl SpatialQuant for Lab<D65, f64> {
                             / dithering_level.powi(2))
                         .exp();
                         sum += val;
-                        *filter_weights.get_mut(i as usize, j as usize).unwrap() =
-                            Self::new(val, val, val);
+                        *filter_weights
+                            .get_mut(i as usize, j as usize)
+                            .expect("filter weights index in range") = Self::new(val, val, val);
                     }
                 }
                 filter_weights.iter_mut().for_each(|fw| *fw /= sum);
@@ -90,7 +92,8 @@ impl SpatialQuant for Lab<D65, f64> {
         // Reflect s above the diagonal
         for v in 0..s.width() {
             for alpha in 0..v {
-                *s.get_mut(v, alpha).unwrap() = *s.get(alpha, v).unwrap();
+                *s.get_mut(v, alpha).ok_or("Could not reflect s")? =
+                    *s.get(alpha, v).ok_or("Could not reflect s")?;
             }
         }
 
@@ -98,8 +101,12 @@ impl SpatialQuant for Lab<D65, f64> {
         for (v, r_item) in r.iter_mut().enumerate().take(palette.len()) {
             for i_y in 0..coarse_variables.height() {
                 for i_x in 0..coarse_variables.width() {
-                    *r_item +=
-                        *a.get(i_x, i_y).unwrap() * *coarse_variables.get(i_x, i_y, v).unwrap();
+                    *r_item += *a
+                        .get(i_x, i_y)
+                        .ok_or("Could not access a-matrix in refine palette")?
+                        * *coarse_variables
+                            .get(i_x, i_y, v)
+                            .ok_or("Could not access coarse variables to refine palette")?;
                 }
             }
         }

--- a/src/color/rgb.rs
+++ b/src/color/rgb.rs
@@ -150,8 +150,9 @@ impl SpatialQuant for Rgb {
                             / dithering_level.powi(2))
                         .exp();
                         sum += val;
-                        *filter_weights.get_mut(i as usize, j as usize).unwrap() =
-                            Self::new(val, val, val);
+                        *filter_weights
+                            .get_mut(i as usize, j as usize)
+                            .expect("filter weights index in range") = Self::new(val, val, val);
                     }
                 }
                 filter_weights.iter_mut().for_each(|fw| *fw /= sum);
@@ -165,8 +166,9 @@ impl SpatialQuant for Rgb {
                             / dithering_level.powi(2))
                         .exp();
                         sum += val;
-                        *filter_weights.get_mut(i as usize, j as usize).unwrap() =
-                            Self::new(val, val, val);
+                        *filter_weights
+                            .get_mut(i as usize, j as usize)
+                            .expect("filter weights index in range") = Self::new(val, val, val);
                     }
                 }
                 filter_weights.iter_mut().for_each(|fw| *fw /= sum);
@@ -224,7 +226,8 @@ impl SpatialQuant for Rgb {
         // Reflect s above the diagonal
         for v in 0..s.width() {
             for alpha in 0..v {
-                *s.get_mut(v, alpha).unwrap() = *s.get(alpha, v).unwrap();
+                *s.get_mut(v, alpha).ok_or("Could not reflect s")? =
+                    *s.get(alpha, v).ok_or("Could not reflect s")?;
             }
         }
 
@@ -232,8 +235,11 @@ impl SpatialQuant for Rgb {
         for (v, r_item) in r.iter_mut().enumerate().take(palette.len()) {
             for i_y in 0..coarse_variables.height() {
                 for i_x in 0..coarse_variables.width() {
-                    *r_item +=
-                        *coarse_variables.get(i_x, i_y, v).unwrap() * *a.get(i_x, i_y).unwrap();
+                    *r_item += *coarse_variables
+                        .get(i_x, i_y, v)
+                        .ok_or("Could not access a-matrix to refine palette")?
+                        * *a.get(i_x, i_y)
+                            .ok_or("Could not access coarse variables to refine palette")?;
                 }
             }
         }

--- a/src/error.rs
+++ b/src/error.rs
@@ -10,8 +10,9 @@ pub enum QuantError {
 impl std::fmt::Display for QuantError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match *self {
-            QuantError::Parameter(ref err) => write!(f, "{}", err),
-            QuantError::Quantization(ref err) => write!(f, "{}", err),
+            QuantError::Parameter(ref err) | QuantError::Quantization(ref err) => {
+                write!(f, "{}", err)
+            }
         }
     }
 }
@@ -19,8 +20,7 @@ impl std::fmt::Display for QuantError {
 impl std::error::Error for QuantError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
-            QuantError::Parameter(_) => None,
-            QuantError::Quantization(_) => None,
+            QuantError::Parameter(_) | QuantError::Quantization(_) => None,
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,9 +86,12 @@
 //!     .collect::<Vec<[u8; 3]>>();
 //!
 //! // Create the final image by color lookup from the palette
-//! quantized_image.iter().for_each(|&c| {
-//!     imgbuf.extend_from_slice(&*palette.get(c as usize).unwrap());
-//! });
+//! for &c in quantized_image.iter() {
+//!     let color = palette
+//!         .get(c as usize)
+//!         .ok_or("Could not retrieve color from palette")?;
+//!     imgbuf.extend_from_slice(color);
+//! }
 //!
 //! # Ok(())
 //! # }


### PR DESCRIPTION
Change get/get_mut for Matrix2d and Matrix3d to use checked math, this alters the behavior of the algorithm
Change ok_or_else for Error to ok_or
Remove unwraps
Update cargo dependencies
Update Cargo.toml exclude
Bump crate version to 0.1.2
Update changelog
Add build status icon to readme
Change main.rs to use non-deprecated `image` function

Note on expects:
- some exist in Matrix2d and the SpatialQuant trait
- will be removed on the next breaking version change